### PR TITLE
LIBFCREPO-1104. Update the base openjdk docker image to one that supports arm64 builds.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # where <VERSION> is the Docker image version to create.
 
 # generic Fuseki image
-FROM openjdk:8u265-jdk-buster AS fuseki
+FROM openjdk:8u312-jdk-bullseye AS fuseki
 
 ENV FUSEKI_VERSION 2.3.1
 ENV FUSEKI_HOME /opt/apache-jena-fuseki-${FUSEKI_VERSION}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,20 @@
 FROM openjdk:8u312-jdk-bullseye AS fuseki
 
 ENV FUSEKI_VERSION 2.3.1
+ENV FUSEKI_URL https://archive.apache.org/dist/jena/binaries/apache-jena-fuseki-${FUSEKI_VERSION}.tar.gz
 ENV FUSEKI_HOME /opt/apache-jena-fuseki-${FUSEKI_VERSION}
 ENV FUSEKI_BASE /var/opt/fuseki
 ENV FUSEKI_DATA_DIR $FUSEKI_BASE/databases
 
-RUN curl -Ls https://archive.apache.org/dist/jena/binaries/apache-jena-fuseki-${FUSEKI_VERSION}.tar.gz \
-    | tar xvzf - --directory /opt
+# Download and install Fuseki.
+# We need to run this as three separate commands instead of a single
+# "curl ... | tar xvzf - ..." pipeline due to some problems with how
+# QEMU handles pipes and sub-processes when running multi-platform
+# Docker builds on Kubernetes.
+RUN curl -Ls "$FUSEKI_URL" -o /tmp/fuseki.tar.gz
+RUN gzip -d /tmp/fuseki.tar.gz
+RUN tar xvf /tmp/fuseki.tar --directory /opt
+RUN rm /tmp/fuseki.tar
 
 RUN mkdir -p "$FUSEKI_BASE"/{DB,logs}
 
@@ -29,7 +37,7 @@ CMD ["./fuseki", "run"]
 FROM fuseki
 
 # Allow JRE to use up to 75% of the RAM in the container
-ENV JAVA_OPTIONS=-XX:MaxRAMPercentage=75.0
+ENV JAVA_OPTIONS -XX:MaxRAMPercentage=75.0
 
 COPY configuration/* $FUSEKI_BASE/configuration/
 COPY shiro.ini $FUSEKI_BASE/


### PR DESCRIPTION
Uses openjdk:8u312-jdk-bullseye.

Separate the curl | tar pipeline into separate RUN commands; works around a problem with QEMU builds on Kubernetes where the pipeline and/or sub-processes don't get started correctly.

https://issues.umd.edu/browse/LIBFCREPO-1104