### PR TITLE
LIBFCREPO-1714. Update JDK to temurin 8u462-b08.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,13 @@
 # where <VERSION> is the Docker image version to create.
 
 # generic Fuseki image
-FROM openjdk:8u312-jdk-bullseye AS fuseki
+FROM eclipse-temurin:8u462-b08-jdk-jammy AS fuseki
 
-ENV FUSEKI_VERSION 2.3.1
-ENV FUSEKI_URL https://archive.apache.org/dist/jena/binaries/apache-jena-fuseki-${FUSEKI_VERSION}.tar.gz
-ENV FUSEKI_HOME /opt/apache-jena-fuseki-${FUSEKI_VERSION}
-ENV FUSEKI_BASE /var/opt/fuseki
-ENV FUSEKI_DATA_DIR $FUSEKI_BASE/databases
+ENV FUSEKI_VERSION=2.3.1
+ENV FUSEKI_URL=https://archive.apache.org/dist/jena/binaries/apache-jena-fuseki-${FUSEKI_VERSION}.tar.gz
+ENV FUSEKI_HOME=/opt/apache-jena-fuseki-${FUSEKI_VERSION}
+ENV FUSEKI_BASE=/var/opt/fuseki
+ENV FUSEKI_DATA_DIR=$FUSEKI_BASE/databases
 
 # Download and install Fuseki.
 # We need to run this as three separate commands instead of a single
@@ -37,7 +37,7 @@ CMD ["./fuseki", "run"]
 FROM fuseki
 
 # Allow JRE to use up to 75% of the RAM in the container
-ENV JAVA_OPTIONS -XX:MaxRAMPercentage=75.0
+ENV JAVA_OPTIONS="-XX:MaxRAMPercentage=75.0"
 
 COPY configuration/* $FUSEKI_BASE/configuration/
 COPY shiro.ini $FUSEKI_BASE/

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # where <VERSION> is the Docker image version to create.
 
 # generic Fuseki image
-FROM eclipse-temurin:8u462-b08-jdk-jammy AS fuseki
+FROM eclipse-temurin:8-jdk-jammy AS fuseki
 
 ENV FUSEKI_VERSION=2.3.1
 ENV FUSEKI_URL=https://archive.apache.org/dist/jena/binaries/apache-jena-fuseki-${FUSEKI_VERSION}.tar.gz


### PR DESCRIPTION
- also updated `ENV` statements in Dockerfile to use preferred `ENV=` syntax

https://umd-dit.atlassian.net/browse/LIBFCREPO-1714